### PR TITLE
Guard flow rate

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -601,13 +601,13 @@ class Controller(object):
     @property
     def flow_rate(self):
         """Return flow rate"""
+        if not self.flow_sensor_enabled:
+            return None
+
         fpr0 = self._get_option("fpr0")
         fpr1 = self._get_option("fpr1")
         flwrt = self._get_variable("flwrt")
         flcrt = self._get_variable("flcrt")
-
-        if not fpr0 or not fpr1 or not flwrt or not flcrt:
-            return None
 
         return (flcrt * ((fpr1 << 8) + fpr0) / 100) / (flwrt / 60)
 

--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -609,7 +609,10 @@ class Controller(object):
         flwrt = self._get_variable("flwrt")
         flcrt = self._get_variable("flcrt")
 
-        return (flcrt * ((fpr1 << 8) + fpr0) / 100) / (flwrt / 60)
+        try:
+            return (flcrt * ((fpr1 << 8) + fpr0) / 100) / (flwrt / 60)
+        except (TypeError, ZeroDivisionError):
+            return None
 
     @property
     def flow_count_window(self):


### PR DESCRIPTION
Suggested guard clause for `flow_rate` as `fpr0` and `fpr1` can legitimately be 0 and will incorrectly trip the current flasey test.