### PR TITLE
Invalid IP addresses returned when dhcp is not in use

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -206,7 +206,7 @@ class Controller(object):
         for i in [1, 2, 3, 4]:
             option = option_name_prefix + str(i)
             octet = self._get_option(option)
-            if len(str(octet)) < 1:
+            if octet is None or len(str(octet)) < 1:
                 return None
 
             ip = ip + str(octet)


### PR DESCRIPTION
Library generates a malformed ip addresses of type `string` containing "None.None.None.None" for `ip_address`, `gw_address` and `dns_address` when associated fields are not present in the OS api response.

The 2.1.9 api states that these fields are ignored/(missing) if dhcp is being used. Firmware codebase [shows](https://github.com/PeteBa/OpenSprinkler-Firmware/blob/8ae9af054153b12d5d90eb2befd0a593419ef168/server.cpp#L969) this is true for all non-Arduino platforms (i.e. OSPi).

This PR forces a `None` result rather than malformed string.