### PR TITLE
fix: end time account for start time for sequential station

### DIFF
--- a/pyopensprinkler/station.py
+++ b/pyopensprinkler/station.py
@@ -204,7 +204,9 @@ class Station(object):
         """Retrieve end time"""
         if self.start_time == 0:
             return 0
-        return self._controller.device_time + self.seconds_remaining
+        return (
+            max(self.start_time, self._controller.device_time) + self.seconds_remaining
+        )
 
     @property
     def max_name_length(self):


### PR DESCRIPTION
Fixes #45 

Waiting stations have a start time in the future so use the larger value between start time or device time when calculating end time