### PR TITLE
fix: last reboot time

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -339,6 +339,8 @@ class Controller(object):
         return ip
 
     def _timestamp_to_utc(self, timestamp):
+        if timestamp == None:
+            return None
         offset = (self._get_option("tz") - 48) * 15 * 60
         return timestamp if timestamp == 0 else timestamp - offset
 

--- a/tests/run_on_firmware.py
+++ b/tests/run_on_firmware.py
@@ -18,6 +18,18 @@ class TestFirmware:
         assert self._controller.firmware_version, int(FIRMWARE_VERSION)
         assert self._controller.firmware_minor_version >= 0
 
+    @pytest.mark.skipif(FIRMWARE_VERSION > 217, reason="only for version 217 and below")
+    def test_last_reboot_time_old(self):
+        self._controller.refresh()
+        assert self._controller.last_reboot_time == None
+
+    @pytest.mark.skipif(
+        FIRMWARE_VERSION <= 217, reason="only for version 218 and above"
+    )
+    def test_last_reboot_time_new(self):
+        self._controller.refresh()
+        assert self._controller.last_reboot_time >= 0
+
     @pytest.mark.skipif(FIRMWARE_VERSION > 219, reason="only for version 219 and below")
     def test_no_mac_address(self):
         self._controller.refresh()


### PR DESCRIPTION
Firmware 2.1.7 and below does not have `lupt`. Added none check for `_timestamp_to_utc`

Ref: https://github.com/vinteo/hass-opensprinkler/issues/120