### PR TITLE
Support start times, days, durations

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,7 +37,7 @@ jobs:
       # Checkout the code base #
       ##########################
       - name: Checkout Code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       ################################
       # Run Linter against code base #

--- a/.gitignore
+++ b/.gitignore
@@ -129,6 +129,7 @@ dmypy.json
 .pyre/
 
 .vscode
+.vs/
 
 bin/
 pyvenv.cfg

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -57,3 +57,28 @@ class TestProgram:
         await program.set_start_time_type(0)
         assert program.start_time_type == 0
         assert program.start_time_type_name == "repeating"
+
+    @pytest.mark.asyncio
+    async def test_set_name(self, controller, program):
+        await program.set_name("Test")
+        assert program.name == "Test"
+
+    @pytest.mark.asyncio
+    async def test_set_program_start_time(self, controller, program):
+        await program.set_program_start_time(0, 360)
+        assert program.program_start_times[0] == 360
+
+    @pytest.mark.asyncio
+    async def test_set_station_duration(self, controller, program):
+        await program.set_station_duration(0, 1800)
+        assert program.station_durations[0] == 1800
+
+    @pytest.mark.asyncio
+    async def test_set_days0(self, controller, program):
+        await program.set_days0(1)
+        assert program.days0 == 1
+
+    @pytest.mark.asyncio
+    async def test_set_days1(self, controller, program):
+        await program.set_days1(3)
+        assert program.days1 == 3


### PR DESCRIPTION
Added support for day0 and day1 (start, interval days).
Added support for program station durations.
Added support for program start times.

Resolved issue with setting program name so that above new features would work. (Seems that the name parameter must follow the "v" parameter or controller will throw a "Data Missing" error: 16).

Tested (using updated hass-opensprinkler) against firmware 2.2.0 (2) and 2.1.9

Here's a sample HA panel. Days and durations can be edited directly (as on left side of panel) or require clicking to more-info popup to change (as on right side of panel), depending on the type of card used (entities on left, custom:timer-bar-card on right).

![IrrigationPane](https://github.com/vinteo/py-opensprinkler/assets/56356940/417a1dbe-2098-49cf-9cc3-b0b59aea25b7)
