### PR TITLE
Use configured weather adjustment when running program

### DIFF
--- a/pyopensprinkler/program.py
+++ b/pyopensprinkler/program.py
@@ -46,9 +46,11 @@ class Program(object):
         content = await self._controller.request("/cp", params)
         return content["result"]
 
-    async def _manual_run(self):
+    async def _manual_run(self, uwt=None):
         """Run program"""
-        params = {"pid": self._index, "uwt": 0}
+        if uwt is None:
+            uwt = self.use_weather_adjustments
+        params = {"pid": self._index, "uwt": int(uwt)}
         content = await self._controller.request("/mp", params)
         return content["result"]
 
@@ -152,9 +154,9 @@ class Program(object):
         else:
             return await self._set_variable("en", 0)
 
-    async def run(self):
+    async def run(self, uwt=None):
         """Run program"""
-        return await self._manual_run()
+        return await self._manual_run(uwt)
 
     async def set_name(self, name):
         dlist = self._get_program_data().copy()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -1,4 +1,7 @@
+import asyncio
+
 import pytest
+from const import FIRMWARE_VERSION
 
 
 @pytest.fixture
@@ -31,6 +34,72 @@ class TestProgram:
         await program.set_odd_even_restriction(0)
         assert program.odd_even_restriction == 0
         assert program.odd_even_restriction_name is None
+
+    @pytest.mark.skipif(
+        FIRMWARE_VERSION <= 216, reason="only for version 217 and above"
+    )
+    @pytest.mark.asyncio
+    async def test_program_manual_run(self, controller, program):
+        await program.set_station_duration(0, 25)
+        # controller.set_water_level only works from version 219
+        if FIRMWARE_VERSION >= 219:
+            await controller.set_water_level(20)
+        else:
+            await controller._set_option("o23", 20)
+
+        await program._manual_run()
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 25
+
+        await program._manual_run(1)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 5
+
+        await program._manual_run(0)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 25
+
+    @pytest.mark.skipif(
+        FIRMWARE_VERSION <= 216, reason="only for version 217 and above"
+    )
+    @pytest.mark.asyncio
+    async def test_program_run(self, controller, program):
+        await program.set_station_duration(0, 25)
+        # controller.set_water_level only works from version 219
+        if FIRMWARE_VERSION >= 219:
+            await controller.set_water_level(20)
+        else:
+            await controller._set_option("o23", 20)
+
+        await program.run()
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 25
+
+        await program.run(1)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 5
+
+        await program.run(0)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert (
+            controller.stations[0].end_time - controller.stations[0].start_time
+        ) == 25
 
     @pytest.mark.asyncio
     async def test_program_schedule_type(self, controller, program):


### PR DESCRIPTION
Hi,

I use the [home assistant integration](https://github.com/vinteo/hass-opensprinkler) when you manually run a program it always defaults to not use the water level and runs all stations at 100% level.

This is due to the uwt flag hard coded to 0 in the [program run code](https://github.com/vinteo/py-opensprinkler/blob/2dbc5ddc29a0f6fef23a01e5b86240617a7a3427/pyopensprinkler/program.py#L42)

Changing it to ` params = {"pid": self._index, "uwt": int(self.use_weather_adjustments)}` allows it to follow what is configured in the open sprinkler program.

Fixes #79