### PR TITLE
feat-support-repeating-start-times

### DIFF
--- a/pyopensprinkler/program.py
+++ b/pyopensprinkler/program.py
@@ -219,7 +219,12 @@ class Program(object):
         if value == 1:
             bits[6] = 1
 
-        dlist[0] = self._bits_to_int(bits)
+        # If changing type, data in start1-3 becomes meaningless, so zero out.
+        if dlist[0] != self._bits_to_int(bits):
+            dlist[3][1] = 0
+            dlist[3][2] = 0
+            dlist[3][3] = 0
+            dlist[0] = self._bits_to_int(bits)
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
@@ -284,6 +289,30 @@ class Program(object):
         dlist = self._get_program_data().copy()
         new_start = self._encode_offset_minutes(start_time_offset_type, 0)
         dlist[3][start_index] = new_start
+        params = self._format_program_data(dlist)
+        return await self._set_variables(params)
+
+    async def set_program_start_repeat_count(self, repeat_count):
+        """Set program start repeat count"""
+        if self.start_time_type == 1:
+            raise RuntimeError(
+                "cannot update repeat count when start time type is 'fixed'"
+            )
+
+        dlist = self._get_program_data().copy()
+        dlist[3][1] = repeat_count
+        params = self._format_program_data(dlist)
+        return await self._set_variables(params)
+
+    async def set_program_start_repeat_interval(self, repeat_minutes):
+        """Set program start repeat interval in minutes"""
+        if self.start_time_type == 1:
+            raise RuntimeError(
+                "cannot update repeat count when start time type is 'fixed'"
+            )
+
+        dlist = self._get_program_data().copy()
+        dlist[3][2] = repeat_minutes
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
@@ -460,6 +489,16 @@ class Program(object):
             self.get_program_start_time_offset_type(2),
             self.get_program_start_time_offset_type(3),
         ]
+
+    @property
+    def program_start_repeat_count(self):
+        """Retrieve program start repeat count"""
+        return self._get_variable(3)[1]
+
+    @property
+    def program_start_repeat_interval(self):
+        """Retrieve program start repeat interval in minutes"""
+        return self._get_variable(3)[2]
 
     @property
     def station_durations(self):

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -90,6 +90,18 @@ class TestProgram:
         assert program.get_program_start_time_offset(1) == 30
 
     @pytest.mark.asyncio
+    async def test_set_program_start_repeat_count(self, controller, program):
+        await program.set_start_time_type(0)
+        await program.set_program_start_repeat_count(2)
+        assert program.program_start_repeat_count == 2
+
+    @pytest.mark.asyncio
+    async def test_set_program_start_repeat_interval(self, controller, program):
+        await program.set_start_time_type(0)
+        await program.set_program_start_repeat_interval(60)
+        assert program.program_start_repeat_interval == 60
+
+    @pytest.mark.asyncio
     async def test_set_station_duration(self, controller, program):
         await program.set_station_duration(0, 1800)
         assert program.station_durations[0] == 1800


### PR DESCRIPTION
Feature to support the `Repeating` type of `Additional Start Times` in `OpenSprinkler`. Sets and gets the `Repeat Count` and `Repeat Interval`. 

Also clears out `start1-3` when changing types, as these values hold different types of information depending on the setting of `Fixed` vs. `Repeating`.