### PR TITLE
Fix pause within pause

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -409,6 +409,13 @@ class Controller(object):
         if seconds < 0 or seconds > 86400:
             raise ValueError("pause must be 0 - 86400")
 
+        # Despite the API docs, all calls to the pause function actually just toggle pause - the duration
+        # being zero has little to do with anything. Thus, if we're trying to set a new pause duration,
+        # clear the old one first.
+        await self.refresh()
+        if seconds > 0 and self.pause_active:
+            await self._set_pause(0)
+
         return await self._set_pause(seconds)
 
     async def disable_pause(self):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -123,12 +123,23 @@ class TestController:
         # Enable pause and verify the state and pause time
         PAUSE_SECONDS = 600
         await controller.set_pause(PAUSE_SECONDS)
+        await controller.refresh()
+
         assert controller.pause_active
+        assert controller.pause_time_remaining > PAUSE_SECONDS - 30
+        assert controller.pause_time_remaining <= PAUSE_SECONDS
 
-        assert controller.pause_time_remaining > 570
-        assert controller.pause_time_remaining <= 600
+        # Now try to alter the pause time. This relies on the controller detecting that it is
+        # currently in a pause, clearing it, and setting the new pause duration.
+        PAUSE_SECONDS = 200
+        await controller.set_pause(PAUSE_SECONDS)
+        await controller.refresh()
 
-        # Setting 0 minute pause clears the pause
+        assert controller.pause_active
+        assert controller.pause_time_remaining > PAUSE_SECONDS - 30
+        assert controller.pause_time_remaining <= PAUSE_SECONDS
+
+        # Setting 0 second pause clears the pause
         await controller.set_pause(0)
         assert not controller.pause_active
         assert controller.pause_time_remaining == 0


### PR DESCRIPTION
This fixes the issue raised in vinteo/hass-opensprinkler#276.

It passes in my environment, but given the nature of it I think it makes sense to be well tested by someone else before we merge/release it.