### PR TITLE
fix: cannot update multiple stations

### DIFF
--- a/pyopensprinkler/station.py
+++ b/pyopensprinkler/station.py
@@ -62,15 +62,17 @@ class Station(object):
         return bool(bits[position])
 
     async def _bit_set(self, bit_property, bit_update_name, value):
-        bits = self._controller._state["stations"][bit_property]
+        bit_list = self._controller._state["stations"][bit_property]
         bank = math.floor(self._index / 8)
-        bits = list(reversed([int(x) for x in list("{0:08b}".format(bits[bank]))]))
+        bits = list(reversed([int(x) for x in list("{0:08b}".format(bit_list[bank]))]))
         position = self._index % 8
         value = int(value)
         bits[position] = value
         bits = list(reversed(bits))
         bits = "".join(map(str, bits))
         bits = int(bits, 2)
+        bit_list[bank] = bits
+        self._controller._state["stations"][bit_property] = bit_list
         return await self._set_attribute(bit_update_name + str(bank), bits)
 
     async def run(self, seconds=None):


### PR DESCRIPTION
If multiple station enable or disable actions are submitted quickly, as in a single Home Assistant `Action` with multiple targets, a refresh of the station's state is not requested from the controller until all of the update actions are completed. This results in actions after the first one using outdated information, the result being that earlier actions are overwritten. Only the last update "sticks".

By immediately updating the `self._controller._state["stations"][bit_property]` as bits are changed, this can be avoided. If for some reason the controller cannot perform any of the updates, this will be quickly indicated when state is returned from the controller after the updates are complete.

I only have a single controller with eight zones, so am unable to test the multiple "bank" case, but it should work.

This resolves vinteo/hass-opensprinkler#317.