### PR TITLE
Update __init__.py to discard cookies

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -197,6 +197,8 @@ class Controller(object):
             if "verify_ssl" in self._opts:
                 verify_ssl = self._opts["verify_ssl"]
 
+            self._http_client.cookie_jar.clear()
+
             async with self._http_client.get(
                 url, timeout=timeout, headers=headers, verify_ssl=verify_ssl, auth=auth
             ) as resp:


### PR DESCRIPTION
A recent change (https://docs.aiohttp.org/en/v3.12.0/changes.html) to aiohttp implements some middleware that may cause it to include (large) cookies that can cause the opensprinkler firmware to return 413 Request Too Large, which is misinterpreted as an Authentication Error (https://github.com/vinteo/hass-opensprinkler/issues/330).

This issue does not affect everyone, and it's unclear where the offending cookies are coming from, but there is no good reason to be sending cookies here, so it should be safe to clear them.