### PR TITLE
feat: add qo and ssta parameters for station and program manual runs

### DIFF
--- a/pyopensprinkler/program.py
+++ b/pyopensprinkler/program.py
@@ -46,11 +46,13 @@ class Program(object):
         content = await self._controller.request("/cp", params)
         return content["result"]
 
-    async def _manual_run(self, uwt=None):
+    async def _manual_run(self, uwt=None, qo=None):
         """Run program"""
         if uwt is None:
             uwt = self.use_weather_adjustments
         params = {"pid": self._index, "uwt": int(uwt)}
+        if qo is not None:
+            params["qo"] = qo
         content = await self._controller.request("/mp", params)
         return content["result"]
 
@@ -154,9 +156,9 @@ class Program(object):
         else:
             return await self._set_variable("en", 0)
 
-    async def run(self, uwt=None):
+    async def run(self, uwt=None, qo=None):
         """Run program"""
-        return await self._manual_run(uwt)
+        return await self._manual_run(uwt, qo)
 
     async def set_name(self, name):
         dlist = self._get_program_data().copy()

--- a/pyopensprinkler/station.py
+++ b/pyopensprinkler/station.py
@@ -75,16 +75,20 @@ class Station(object):
         self._controller._state["stations"][bit_property] = bit_list
         return await self._set_attribute(bit_update_name + str(bank), bits)
 
-    async def run(self, seconds=None):
+    async def run(self, seconds=None, qo=None):
         """Run station"""
         if seconds is None:
             seconds = 60
         params = {"en": 1, "t": seconds}
+        if qo is not None:
+            params["qo"] = qo
         return await self._manual_run(params)
 
-    async def stop(self):
+    async def stop(self, ssta=None):
         """Stop station"""
         params = {"en": 0}
+        if ssta is not None:
+            params["ssta"] = int(ssta)
         return await self._manual_run(params)
 
     async def toggle(self):

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -68,6 +68,13 @@ class TestProgram:
             controller.stations[0].end_time - controller.stations[0].start_time
         ) == 25
 
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_program_run_with_qo(self, controller, program):
+        await program.set_station_duration(0, 25)
+        assert await program.run(qo=0)
+        await controller.stations[0].stop()
+
     @pytest.mark.skipif(
         FIRMWARE_VERSION <= 216, reason="only for version 217 and above"
     )

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -146,3 +146,20 @@ class TestStation:
 
         await controller.stations[0].set_sequential_operation(False)
         assert not controller.stations[0].sequential_operation
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_run_with_qo(self, controller):
+        await controller.refresh()
+        assert await controller.stations[0].run(seconds=30, qo=0)
+        assert controller.stations[0].is_running
+        await controller.stations[0].stop()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_stop_with_ssta(self, controller):
+        await controller.refresh()
+        await controller.stations[0].run(seconds=30)
+        assert controller.stations[0].is_running
+        assert await controller.stations[0].stop(ssta=True)
+        assert not controller.stations[0].is_running


### PR DESCRIPTION
Exposes three parameters introduced in the [firmware 2.2.1(4) API](https://opensprinkler.github.io/OpenSprinkler-Firmware/2.2.1/221_4_api/).

### `/cm` — Manual station run (`Station.run` / `Station.stop`)

**`qo`** (queuing option, applies when opening a zone):
- `0` — append after other zones in queue (default)
- `1` — insert ahead of other zones in queue

**`ssta`** (shift stations, applies when closing a zone via `en=0`):
- `False` / `0` — don't shift remaining stations in the sequential group (default)
- `True` / `1` — shift remaining stations

### `/mp` — Manual program run (`Program.run`)

**`qo`** (queuing option):
- `0` — append program to end of queue
- `1` — insert program at front of queue
- `2` — replace: reset all zones, clear queue, then start the program (firmware default)

`ssta` accepts a bool and converts to int, consistent with how `uwt` is handled. `qo` is kept as an int since the `/mp` variant has three valid values.