### PR TITLE
feat: add uwt and qo parameters to run_once_program

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -441,14 +441,15 @@ class Controller(object):
 
         return await self._set_option("wl", level)
 
-    async def run_once_program(self, station_times):
+    async def run_once_program(self, station_times, uwt=None, qo=None):
         """Run once program"""
-        params = {"t": station_times}
-
-        t = json.dumps(params.pop("t", None)).replace(" ", "")
-        t = t.strip()
-
-        content = await self.request("/cr", None, f"t={t}")
+        t = json.dumps(station_times).replace(" ", "").strip()
+        params = {}
+        if uwt is not None:
+            params["uwt"] = uwt
+        if qo is not None:
+            params["qo"] = qo
+        content = await self.request("/cr", params, f"t={t}")
         return content["result"]
 
     async def set_password(self, password):

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -138,3 +138,62 @@ class TestController:
             await controller.set_pause(-1)
         with pytest.raises(ValueError):
             await controller.set_pause(86400 + 1)
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_run_once_program_uwt(self, controller):
+        await controller.refresh()
+        await controller.set_water_level(20)
+        station_times = [25] + [0] * (len(controller.stations) - 1)
+
+        # uwt=0: no weather adjustment → full 25 seconds
+        await controller.run_once_program(station_times, uwt=0)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert controller.stations[0].end_time - controller.stations[0].start_time == 25
+        await controller.stop_all_stations()
+
+        # uwt=1: apply 20% water level → 25 * 0.20 = 5 seconds
+        await controller.run_once_program(station_times, uwt=1)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert controller.stations[0].end_time - controller.stations[0].start_time == 5
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_run_once_program_qo_append(self, controller):
+        await controller.refresh()
+        # Start station 0 manually; qo=0 (append) must not cancel it
+        await controller.stations[0].run(seconds=60)
+        assert controller.stations[0].is_running
+        station_times = [0, 30] + [0] * (len(controller.stations) - 2)
+        await controller.run_once_program(station_times, qo=0)
+        assert controller.stations[0].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_run_once_program_qo_replace(self, controller):
+        await controller.refresh()
+        # Start station 0 manually; qo=2 (replace) must cancel it and start station 1
+        await controller.stations[0].run(seconds=60)
+        assert controller.stations[0].is_running
+        station_times = [0, 30] + [0] * (len(controller.stations) - 2)
+        await controller.run_once_program(station_times, qo=2)
+        assert not controller.stations[0].is_running
+        assert controller.stations[1].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_run_once_program_uwt_and_qo(self, controller):
+        await controller.refresh()
+        await controller.set_water_level(20)
+        # qo=2: clear queue; uwt=1 with 20% water level → 25 * 0.20 = 5 seconds
+        station_times = [25] + [0] * (len(controller.stations) - 1)
+        await controller.run_once_program(station_times, uwt=1, qo=2)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert controller.stations[0].end_time - controller.stations[0].start_time == 5
+        await controller.stop_all_stations()

--- a/tests/test_program.py
+++ b/tests/test_program.py
@@ -70,10 +70,49 @@ class TestProgram:
 
     @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
     @pytest.mark.asyncio
-    async def test_program_run_with_qo(self, controller, program):
+    async def test_program_run_with_qo_append(self, controller, program):
         await program.set_station_duration(0, 25)
+        # Start station 1 manually; qo=0 (append) must not cancel it
+        await controller.stations[1].run(seconds=60)
+        assert controller.stations[1].is_running
         assert await program.run(qo=0)
-        await controller.stations[0].stop()
+        assert controller.stations[1].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_program_run_with_qo_preempt(self, controller, program):
+        await program.set_station_duration(0, 25)
+        # Start station 1 manually; qo=1 (insert ahead) must not cancel it either
+        await controller.stations[1].run(seconds=60)
+        assert controller.stations[1].is_running
+        assert await program.run(qo=1)
+        assert controller.stations[1].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_program_run_with_qo_replace(self, controller, program):
+        await program.set_station_duration(0, 25)
+        # Start station 1 manually; qo=2 (replace) must cancel it and start the program
+        await controller.stations[1].run(seconds=60)
+        assert controller.stations[1].is_running
+        assert await program.run(qo=2)
+        assert not controller.stations[1].is_running
+        assert controller.stations[0].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_program_run_with_uwt_and_qo(self, controller, program):
+        await program.set_station_duration(0, 25)
+        await controller.set_water_level(20)
+        # qo=2: clear queue; uwt=True with 20% water level → 25 * 0.20 = 5 seconds
+        assert await program.run(uwt=True, qo=2)
+        await asyncio.sleep(1)
+        await controller.refresh()
+        assert controller.stations[0].end_time - controller.stations[0].start_time == 5
+        await controller.stop_all_stations()
 
     @pytest.mark.skipif(
         FIRMWARE_VERSION <= 216, reason="only for version 217 and above"

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -149,17 +149,52 @@ class TestStation:
 
     @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
     @pytest.mark.asyncio
-    async def test_run_with_qo(self, controller):
+    async def test_run_with_qo_append(self, controller):
         await controller.refresh()
-        assert await controller.stations[0].run(seconds=30, qo=0)
+        await controller.stations[0].run(seconds=60)
         assert controller.stations[0].is_running
-        await controller.stations[0].stop()
+        # qo=0 (append): queue station 1, must not cancel the currently running station 0
+        await controller.stations[1].run(seconds=30, qo=0)
+        assert controller.stations[0].is_running
+        await controller.stop_all_stations()
 
     @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
     @pytest.mark.asyncio
-    async def test_stop_with_ssta(self, controller):
+    async def test_run_with_qo_preempt(self, controller):
         await controller.refresh()
-        await controller.stations[0].run(seconds=30)
+        await controller.stations[0].run(seconds=60)
         assert controller.stations[0].is_running
-        assert await controller.stations[0].stop(ssta=True)
+        # qo=1 (insert ahead): station 1 should start running immediately
+        await controller.stations[1].run(seconds=30, qo=1)
+        assert controller.stations[1].is_running
         assert not controller.stations[0].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_stop_with_ssta_shifts_queue(self, controller):
+        await controller.refresh()
+        # Queue two stations via run_once; station 0 runs first, station 1 is waiting
+        station_times = [30, 30] + [0] * (len(controller.stations) - 2)
+        await controller.run_once_program(station_times, qo=2)
+        assert controller.stations[0].is_running
+        assert not controller.stations[1].is_running
+        # ssta=True: stopping station 0 shifts station 1 forward — it should start immediately
+        await controller.stations[0].stop(ssta=True)
+        assert not controller.stations[0].is_running
+        assert controller.stations[1].is_running
+        await controller.stop_all_stations()
+
+    @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
+    @pytest.mark.asyncio
+    async def test_stop_without_ssta_preserves_queue(self, controller):
+        await controller.refresh()
+        station_times = [30, 30] + [0] * (len(controller.stations) - 2)
+        await controller.run_once_program(station_times, qo=2)
+        assert controller.stations[0].is_running
+        assert not controller.stations[1].is_running
+        # No ssta: stopping station 0 does not shift station 1 — it stays waiting
+        await controller.stations[0].stop()
+        assert not controller.stations[0].is_running
+        assert not controller.stations[1].is_running
+        await controller.stop_all_stations()


### PR DESCRIPTION
Follow-up to #112 — the new queuing parameter (`qo`) and `uwt` were missing from `Controller.run_once_program`. Both are optional and only included in the `/cr` request when explicitly set.

Also expands the `qo` / `ssta` tests for stations and programs to assert the actual append / preempt / replace / shift semantics rather than just exercising the parameter.