### PR TITLE
Feature: Add new scheduling options station delay, station groups

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -394,6 +394,17 @@ class Controller(object):
     async def disable_rain_delay(self):
         return await self._set_variable("rd", 0)
 
+    async def set_station_delay(self, seconds):
+        """
+        Set station delay time (in seconds). Range is -600 to 600 in increments of 5 seconds.
+        """
+
+        if (not -600 <= seconds <= 600) or (seconds % 5 != 0):
+            raise ValueError(
+                "Delay must be in seconds between -600 to 600 in increments of 5 seconds"
+            )
+        return await self._set_option("sdt", seconds)
+
     async def set_pause(self, seconds):
         """
         Set pause time (in seconds). Range 0 - 86400 (24 hours). A value of 0 cancels any current pause.
@@ -657,6 +668,11 @@ class Controller(object):
     def current_draw(self):
         """Retrieve current draw in mA"""
         return self._get_variable("curr")
+
+    @property
+    def station_delay(self):
+        """Retrieve station delay in seconds"""
+        return self._get_option("sdt")
 
     @property
     def master_station_1(self):

--- a/pyopensprinkler/program.py
+++ b/pyopensprinkler/program.py
@@ -28,6 +28,7 @@ from pyopensprinkler.const import (
 )
 
 from .exceptions import FirmwareNotSupportedError
+from .utils import _is_new_feature_supported
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -181,14 +182,6 @@ class Program(object):
             return False
         return True
 
-    def _is_required_version(self, version, minor_version):
-        if self._controller.firmware_version > version:
-            return True
-        elif self._controller.firmware_version == version:
-            return self._controller.firmware_minor_version >= minor_version
-        else:
-            return False
-
     async def enable(self):
         """Enable operation"""
         return await self.set_enabled(True)
@@ -246,7 +239,7 @@ class Program(object):
         if value in [
             SCHEDULE_TYPE_SINGLE_RUN_CODE,
             SCHEDULE_TYPE_MONTHLY_CODE,
-        ] and not self._is_required_version(221, 1):
+        ] and not _is_new_feature_supported(self._controller, 221, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.1(1)")
 
         if not 0 <= value <= 3:
@@ -486,7 +479,7 @@ class Program(object):
 
     async def set_date_range_from(self, start_month: int, start_day: int):
         """Set program date range start date"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
         if not self._is_valid_date(start_month, start_day):
@@ -499,7 +492,7 @@ class Program(object):
 
     async def set_date_range_to(self, end_month: int, end_day: int):
         """Set program date range end date"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
         if not self._is_valid_date(end_month, end_day):
@@ -512,7 +505,7 @@ class Program(object):
 
     async def set_date_range_flag(self, enabled: bool):
         """Adjust program date range flag"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
         if enabled < 0 or enabled > 1:
@@ -639,7 +632,7 @@ class Program(object):
     @property
     def date_range_enabled(self):
         """Retrieve Date-range enable flag"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             return 0
         else:
             return self._get_data_flag_bits()[7]
@@ -647,7 +640,7 @@ class Program(object):
     @property
     def date_range_from(self):
         """Retrieve date range start date"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             return 1, 1  # Jan 1 default
         else:
             date_range = self._get_variable(6)
@@ -658,7 +651,7 @@ class Program(object):
     @property
     def date_range_to(self):
         """Retrieve date range end date"""
-        if not self._is_required_version(220, 1):
+        if not _is_new_feature_supported(self._controller, 220, 1):
             return 12, 31  # Dec 31 default
         else:
             date_range = self._get_variable(6)

--- a/pyopensprinkler/station.py
+++ b/pyopensprinkler/station.py
@@ -12,6 +12,9 @@ from pyopensprinkler.const import (
     STATION_TYPE_STANDARD,
 )
 
+from .exceptions import FirmwareNotSupportedError
+from .utils import _is_new_feature_supported, _is_removed_feature_supported
+
 
 class Station(object):
     """Station class with /station/ API calls."""
@@ -131,6 +134,14 @@ class Station(object):
         else:
             return await self._bit_set(bit_property, bit_update_name, False)
 
+    async def set_group(self, value):
+        if not _is_new_feature_supported(self._controller, 220, 1):
+            raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
+
+        if not 0 <= value <= 255:
+            raise ValueError("Value must be between 0 and 255")
+        return await self._set_attribute("g" + str(self.index), value)
+
     async def set_rain_delay_ignored(self, value):
         bit_property = "ignore_rain"
         bit_update_name = "i"
@@ -156,6 +167,9 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_sequential_operation(self, value):
+        if not _is_removed_feature_supported(self._controller, 221, 0):
+            raise FirmwareNotSupportedError("Feature removed in v2.2.1(0)")
+
         bit_property = "stn_seq"
         bit_update_name = "q"
         if value:
@@ -228,6 +242,13 @@ class Station(object):
         return self._bit_check("masop2")
 
     @property
+    def group(self):
+        """Station group"""
+        if not _is_new_feature_supported(self._controller, 220, 1):
+            raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
+        return self._controller._state["stations"]["stn_grp"][self._index]
+
+    @property
     def rain_delay_ignored(self):
         return self._bit_check("ignore_rain")
 
@@ -245,6 +266,9 @@ class Station(object):
 
     @property
     def sequential_operation(self):
+        if not _is_removed_feature_supported(self._controller, 221, 0):
+            raise FirmwareNotSupportedError("Feature removed in v2.2.1(0)")
+
         return self._bit_check("stn_seq")
 
     @property

--- a/pyopensprinkler/utils.py
+++ b/pyopensprinkler/utils.py
@@ -1,0 +1,27 @@
+"""Commonly used functions."""
+
+
+def _is_new_feature_supported(controller, required_version, required_minor_version):
+    """Compare current firmware version with the first supported version of a feature"""
+    firmware_version = controller.firmware_version
+    firmware_minor_version = controller.firmware_minor_version
+    if firmware_version > required_version:
+        return True
+    elif firmware_version == required_version:
+        return firmware_minor_version >= required_minor_version
+    else:
+        return False
+
+
+def _is_removed_feature_supported(
+    controller, last_supported_version, last_supported_minor_version
+):
+    """Compare current firmware version with the last supported version of a feature"""
+    firmware_version = controller.firmware_version
+    firmware_minor_version = controller.firmware_minor_version
+    if firmware_version < last_supported_version:
+        return True
+    elif firmware_version == last_supported_version:
+        return firmware_minor_version <= last_supported_minor_version
+    else:
+        return False

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@
 
 from setuptools import setup
 
-version = "0.7.19"
+version = "0.7.20"
 
 github_username = "vinteo"
 github_repository = "py-opensprinkler"

--- a/tests/test_controller.py
+++ b/tests/test_controller.py
@@ -139,6 +139,31 @@ class TestController:
         with pytest.raises(ValueError):
             await controller.set_pause(86400 + 1)
 
+    @pytest.mark.skipif(FIRMWARE_VERSION < 217, reason="only for version 217 and above")
+    @pytest.mark.asyncio
+    async def test_station_delay(self, controller):
+        await controller.refresh()
+
+        # Enable delay and verify the delay time
+        DELAY_SECONDS = 600
+        await controller.set_station_delay(DELAY_SECONDS)
+        assert controller.station_delay == DELAY_SECONDS
+
+        # Enable delay and verify the delay time
+        DELAY_SECONDS = -600
+        await controller.set_station_delay(DELAY_SECONDS)
+        assert controller.station_delay == DELAY_SECONDS
+
+        # Setting 0 seconds delay clears the delay
+        await controller.set_station_delay(0)
+        assert controller.station_delay == 0
+
+        # Valid range of -600 to 600
+        with pytest.raises(ValueError):
+            await controller.set_station_delay(-601)
+        with pytest.raises(ValueError):
+            await controller.set_station_delay(601)
+
     @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
     @pytest.mark.asyncio
     async def test_run_once_program_uwt(self, controller):

--- a/tests/test_station.py
+++ b/tests/test_station.py
@@ -147,6 +147,25 @@ class TestStation:
         await controller.stations[0].set_sequential_operation(False)
         assert not controller.stations[0].sequential_operation
 
+    @pytest.mark.skipif(FIRMWARE_VERSION < 220, reason="only for version 220 and above")
+    @pytest.mark.asyncio
+    async def test_set_group_operation(self, controller):
+        await controller.refresh()
+
+        GROUP = 0
+        await controller.stations[0].set_group(GROUP)
+        assert controller.stations[0].group == GROUP
+
+        GROUP = 255
+        await controller.stations[0].set_group(GROUP)
+        assert controller.stations[0].group == GROUP
+
+        # Valid range of 0 to 255
+        with pytest.raises(ValueError):
+            await controller.stations[0].set_group(-1)
+        with pytest.raises(ValueError):
+            await controller.stations[0].set_group(256)
+
     @pytest.mark.skipif(FIRMWARE_VERSION < 221, reason="only for version 221 and above")
     @pytest.mark.asyncio
     async def test_run_with_qo_append(self, controller):


### PR DESCRIPTION
This PR adds scheduling options necessary for an upcoming feature in `hass-opensprinkler`. It also marks the `set_sequential_operation` as obsolete. Version test functions have been added in a new `utils.py` file.

Note that there is an outstanding Dependabot vulnerability that recommends an update to `pytest`. Do we want to handle that in the next release?