### PR TITLE
docs: expand docstrings for public API (fixes #3)

### DIFF
--- a/pyopensprinkler/__init__.py
+++ b/pyopensprinkler/__init__.py
@@ -73,7 +73,27 @@ class Controller(object):
     """OpenSprinkler Controller"""
 
     def __init__(self, url, password, opts=None):
-        """OpenSprinkler Controller initializer."""
+        """OpenSprinkler Controller initializer.
+
+        Args:
+            url: Controller URL in the form ``http[s]://hostname[:port]``.
+            password: Controller password (plaintext; MD5-hashed for API calls).
+            opts: Optional dict of connection and behavior options:
+
+                - ``session``: externally managed ``aiohttp.ClientSession`` to
+                  reuse; the caller is responsible for closing it.
+                - ``skip_all_endpoint``: if True, never use the ``/ja``
+                  all-in-one endpoint and always use the per-section
+                  endpoints. Overridden by the
+                  ``PYOPENSPRINKLER_SKIP_ALL_ENDPOINT`` environment variable.
+                - ``auto_refresh_on_update``: dict with ``enabled`` (bool,
+                  default True) and ``settle_time`` (seconds, default 1)
+                  controlling the automatic state refresh after update calls.
+                - ``http_username`` / ``http_password``: HTTP basic auth
+                  credentials when the controller sits behind an
+                  authenticating proxy.
+                - ``verify_ssl``: SSL verification flag passed to aiohttp.
+        """
 
         if opts is None:
             opts = {}
@@ -116,18 +136,41 @@ class Controller(object):
             opts["auto_refresh_on_update"]["settle_time"] = 1
 
     def session_start(self):
+        """Create a new internally managed aiohttp client session."""
         client = aiohttp.ClientSession()
         self._http_client = client
 
     async def session_close(self):
+        """Close the internally managed aiohttp client session.
+
+        Does nothing when an external session was provided via the
+        ``session`` option or when no session has been started.
+        """
         if self._http_client is not None and "session" not in self._opts:
             await self._http_client.close()
             self._http_client = None
 
     async def request(self, path, params=None, raw_qs=None, refresh_on_update=None):
+        """Make a request to the API.
+
+        Args:
+            path: API endpoint path, e.g. ``/jc``.
+            params: Optional dict of query string parameters.
+            raw_qs: Optional pre-encoded query string appended verbatim
+                after ``params``.
+            refresh_on_update: Override the auto-refresh behavior for this
+                call; None defers to the instance configuration.
+
+        Returns:
+            Decoded JSON response as a dict.
+
+        Raises:
+            OpenSprinklerAuthError: If the password is rejected.
+            OpenSprinklerApiError: If the API returns an error result code.
+            OpenSprinklerConnectionError: If the controller is unreachable.
+        """
         if params is None:
             params = {}
-        """Make a request to the API."""
         params["pw"] = self._md5password
         qs = urllib.parse.urlencode(params)
         if raw_qs is not None and len(raw_qs) > 0:
@@ -171,6 +214,7 @@ class Controller(object):
     @synchronized(lock)
     @on_exception(expo, OpenSprinklerConnectionError, max_tries=3)
     async def _request_http(self, url):
+        """Perform the HTTP GET with retries and error mapping."""
         try:
             if self._http_client is None:
                 self.session_start()
@@ -219,7 +263,12 @@ class Controller(object):
             raise OpenSprinklerAuthError("Invalid password") from exc
 
     async def refresh(self):
-        """Refresh programs and stations"""
+        """Refresh programs and stations.
+
+        Fetches the full controller state and rebuilds the ``programs``
+        and ``stations`` dicts. Must be called at least once before
+        reading any state-dependent properties.
+        """
         await self._refresh_state()
         self._last_refresh_time = int(round(datetime.datetime.now().timestamp()))
 
@@ -371,19 +420,41 @@ class Controller(object):
 
     # controller variables
     async def enable(self):
-        """Enable operation"""
+        """Enable controller operation.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("en", 1)
 
     async def disable(self):
-        """Disable operation"""
+        """Disable controller operation.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("en", 0)
 
     async def reboot(self):
+        """Reboot the controller.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("rbt", 1)
 
     async def set_rain_delay(self, hours):
-        """
-        Set rain delay time (in hours). Range is 0 to 32767. A value of 0 turns off rain delay.
+        """Set rain delay time.
+
+        Args:
+            hours: Rain delay in hours, 0-32767. A value of 0 turns off
+                rain delay.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If hours is outside 0-32767.
         """
 
         if hours < 0 or hours > 32767:
@@ -392,11 +463,26 @@ class Controller(object):
         return await self._set_variable("rd", hours)
 
     async def disable_rain_delay(self):
+        """Turn off rain delay.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("rd", 0)
 
     async def set_station_delay(self, seconds):
-        """
-        Set station delay time (in seconds). Range is -600 to 600 in increments of 5 seconds.
+        """Set station delay time.
+
+        Args:
+            seconds: Station delay in seconds, -600 to 600 in increments
+                of 5.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If seconds is outside -600 to 600 or not a
+                multiple of 5.
         """
 
         if (not -600 <= seconds <= 600) or (seconds % 5 != 0):
@@ -406,8 +492,17 @@ class Controller(object):
         return await self._set_option("sdt", seconds)
 
     async def set_pause(self, seconds):
-        """
-        Set pause time (in seconds). Range 0 - 86400 (24 hours). A value of 0 cancels any current pause.
+        """Pause operation of running stations.
+
+        Args:
+            seconds: Pause duration in seconds, 0-86400 (24 hours). A
+                value of 0 cancels any current pause.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If seconds is outside 0-86400.
         """
         # Note that the API does not actually specify a limit, but the UI footer cannot properly
         # represent values above 24 hours so we constrain it to avoid misleading the user.
@@ -417,25 +512,59 @@ class Controller(object):
         return await self._set_pause(seconds)
 
     async def disable_pause(self):
+        """Cancel any current pause.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_pause(0)
 
     async def enable_remote_extension_mode(self):
+        """Enable remote extension mode.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("re", 1)
 
     async def disable_remote_extension_mode(self):
+        """Disable remote extension mode.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("re", 0)
 
     async def stop_all_stations(self):
-        """Stop all running and waiting stations"""
+        """Stop all running and waiting stations.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("rsn", 1)
 
     async def firmware_update(self):
+        """Trigger a firmware update.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("update", 1)
 
     # controller options
     async def set_water_level(self, level):
-        """
-        Water level (i.e. % Watering). Acceptable range is 0 to 250.
+        """Set water level (i.e. % Watering).
+
+        Requires firmware 2.1.9 or newer.
+
+        Args:
+            level: Water level percentage, 0-250.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If level is outside 0-250.
         """
 
         if level < 0 or level > 250:
@@ -444,7 +573,19 @@ class Controller(object):
         return await self._set_option("wl", level)
 
     async def run_once_program(self, station_times, uwt=None, qo=None):
-        """Run once program"""
+        """Run a once-off program with the given per-station durations.
+
+        Args:
+            station_times: List of run durations in seconds, one entry per
+                station (0 to skip a station).
+            uwt: Optional weather adjustment flag (0/1); when 1 the
+                current water level is applied to the durations.
+            qo: Optional queue option; when set the run is queued rather
+                than interrupting running stations.
+
+        Returns:
+            API result code (1 = success).
+        """
         t = json.dumps(station_times).replace(" ", "").strip()
         params = {}
         if uwt is not None:
@@ -455,7 +596,15 @@ class Controller(object):
         return content["result"]
 
     async def set_password(self, password):
-        """Set password"""
+        """Set the controller password.
+
+        Args:
+            password: New plaintext password; stored and used as its MD5
+                hash for subsequent API calls.
+
+        Returns:
+            API result code (1 = success).
+        """
         md5password = hashlib.md5(password.encode("utf-8")).hexdigest()
         params = {"pw": self._md5password, "npw": md5password, "cpw": md5password}
 
@@ -464,40 +613,57 @@ class Controller(object):
         return content["result"]
 
     async def create_program(self, name):
-        """Create new disabled program with first station running for 1 minute on Monday midnight"""
+        """Create a new program.
+
+        The program is created disabled, with the first station running
+        for 1 minute on Monday at midnight.
+
+        Args:
+            name: Name of the new program.
+
+        Returns:
+            API result code (1 = success).
+        """
         params = {"pid": -1, "name": name, "v": "[0,1,0,[0,0,0,0],[60,0,0,0,0,0,0,0]]"}
 
         content = await self.request("/cp", params)
         return content["result"]
 
     async def delete_program(self, index):
-        """Delete program"""
+        """Delete a program.
+
+        Args:
+            index: 0-based index of the program to delete.
+
+        Returns:
+            API result code (1 = success).
+        """
         content = await self.request("/dp", {"pid": index})
         return content["result"]
 
     @property
     def last_refresh_time(self):
-        """Retrieve last refresh time"""
+        """Epoch timestamp of the last successful refresh, or None."""
         return self._last_refresh_time
 
     @property
     def enabled(self):
-        """Retrieve operation enabled"""
+        """Whether controller operation is enabled."""
         return bool(self._get_variable("en"))
 
     @property
     def mac_address(self):
-        """Retrieve controller mac address"""
+        """Controller MAC address."""
         return self._get_variable("mac")
 
     @property
     def firmware_version(self):
-        """Retrieve firmware version"""
+        """Firmware version as an integer, e.g. 219 for 2.1.9."""
         return self._get_option("fwv")
 
     @property
     def firmware_version_name(self):
-        """Retrieve firmware version name"""
+        """Firmware version as a string, e.g. '2.1.9', or None."""
         fwv = self.firmware_version
         try:
             return f"{int(fwv / 100)}.{int(fwv / 10) % 10}.{fwv % 10}"
@@ -506,17 +672,18 @@ class Controller(object):
 
     @property
     def firmware_minor_version(self):
-        """Retrieve firmware minor version"""
+        """Firmware minor version (the number in parentheses), or None."""
         return self._get_option("fwm")
 
     @property
     def hardware_version(self):
-        """Retrieve hardware version"""
+        """Hardware version as an integer, or None."""
         return self._get_option("hwv")
 
     @property
     def hardware_version_name(self):
-        """Retrieve hardware version name"""
+        """Hardware version name, e.g. 'OSPi', 'OSBo', 'Linux', 'Demo',
+        or a 'major.minor' string."""
         if self.hardware_version == HARDWARE_VERSION_OSPI:
             return "OSPi"
 
@@ -538,12 +705,12 @@ class Controller(object):
 
     @property
     def hardware_type(self):
-        """Retrieve hardware type"""
+        """Hardware type integer (0 = AC, 1 = DC, 2 = Latching)."""
         return self._get_option("hwt")
 
     @property
     def hardware_type_name(self):
-        """Retrieve hardware type name"""
+        """Hardware type name ('AC', 'DC', or 'Latching'), or None."""
         if self.hardware_type == HARDWARE_TYPE_AC:
             return "AC"
 
@@ -557,98 +724,98 @@ class Controller(object):
 
     @property
     def device_id(self):
-        """Retrieve device ID"""
+        """Device ID."""
         return self._get_option("devid")
 
     @property
     def device_time(self):
-        """Retrieve device time"""
+        """Controller device time as a UTC epoch timestamp."""
         return self._timestamp_to_utc(self._get_variable("devt"))
 
     @property
     def ignore_password_enabled(self):
-        """Retrieve ignore password"""
+        """Whether the ignore password option is enabled."""
         return bool(self._get_option("ipas"))
 
     @property
     def special_station_auto_refresh_enabled(self):
-        """Retrieve special station auto refresh"""
+        """Whether special station auto refresh is enabled."""
         return bool(self._get_option("sar"))
 
     @property
     def detected_expansion_board_count(self):
-        """Retrieve number of detected expansion boards"""
+        """Number of detected expansion boards."""
         return self._get_option("dexp")
 
     @property
     def maximum_expansion_board_count(self):
-        """Retrieve maximum number of expansion boards"""
+        """Maximum number of supported expansion boards."""
         return self._get_option("mexp")
 
     @property
     def dhcp_enabled(self):
-        """Retrieve dhcp enabled"""
+        """Whether DHCP is enabled."""
         return bool(self._get_option("dhcp"))
 
     @property
     def ip_address(self):
-        """Retrieve controller IP address"""
+        """Controller IP address, or None if not set."""
         return self._ip_from_options("ip")
 
     @property
     def gateway_address(self):
-        """Retrieve controller gateway IP address"""
+        """Controller gateway IP address, or None if not set."""
         return self._ip_from_options("gw")
 
     @property
     def dns_address(self):
-        """Retrieve controller DNS IP address"""
+        """Controller DNS IP address, or None if not set."""
         return self._ip_from_options("dns")
 
     @property
     def ip_subnet(self):
-        """Retrieve controller IP subnet"""
+        """Controller IP subnet, or None if not set."""
         return self._ip_from_options("subn")
 
     @property
     def ntp_address(self):
-        """Retrieve controller NTP IP address"""
+        """Controller NTP IP address, or None if not set."""
         return self._ip_from_options("ntp")
 
     @property
     def ntp_enabled(self):
-        """Retrieve NTP enabled"""
+        """Whether NTP is enabled."""
         return bool(self._get_option("ntp"))
 
     # lrun [station index, program index, duration, end time]
     @property
     def last_run_station(self):
-        """Retrieve last run station"""
+        """Station index of the last station run."""
         return self._get_variable("lrun")[0]
 
     @property
     def last_run_program(self):
-        """Retrieve last run program"""
+        """Program index of the last station run (0 for manual runs)."""
         return self._get_variable("lrun")[1]
 
     @property
     def last_run_duration(self):
-        """Retrieve last run duration"""
+        """Duration of the last station run in seconds."""
         return self._get_variable("lrun")[2]
 
     @property
     def last_run_end_time(self):
-        """Retrieve last run end time"""
+        """End time of the last station run as a UTC epoch timestamp."""
         return self._timestamp_to_utc(self._get_variable("lrun")[3])
 
     @property
     def rssi(self):
-        """Retrieve RSSI"""
+        """WiFi signal strength (RSSI), or None if not reported."""
         return self._get_variable("RSSI")
 
     @property
     def latitude(self):
-        """Retrieve latitude"""
+        """Configured latitude, or None if location is not set."""
         loc = self._get_variable("loc")
         if len(loc) < 1 or "," not in loc:
             return None
@@ -657,7 +824,7 @@ class Controller(object):
 
     @property
     def longitude(self):
-        """Retrieve longitude"""
+        """Configured longitude, or None if location is not set."""
         loc = self._get_variable("loc")
         if len(loc) < 1 or "," not in loc:
             return None
@@ -666,83 +833,67 @@ class Controller(object):
 
     @property
     def current_draw(self):
-        """Retrieve current draw in mA"""
+        """Current draw in mA."""
         return self._get_variable("curr")
 
     @property
     def station_delay(self):
-        """Retrieve station delay in seconds"""
+        """Station delay in seconds."""
         return self._get_option("sdt")
 
     @property
     def master_station_1(self):
-        """
-        Retrieve master station 1
-
-        Note this value is 1 indexed, 0 means disabled
-        """
+        """Master station 1 index (1-based; 0 means disabled)."""
         return self._get_option("mas")
 
     @property
     def master_station_1_time_on_adjustment(self):
-        """
-        Master 1 and 2 on adjusted time (in steps of 5 seconds). Acceptable range is 0 to 600 (note: positive).
-        """
+        """Master 1 on adjustment time (steps of 5 seconds, 0 to 600)."""
         return self._get_option("mton")
 
     @property
     def master_station_1_time_off_adjustment(self):
-        """
-        Master 1 and 2 off adjusted time (in steps of 5 seconds). Acceptable range is -600 to 0 (note: negative).
-        """
+        """Master 1 off adjustment time (steps of 5 seconds, -600 to 0)."""
         return self._get_option("mtof")
 
     @property
     def master_station_2(self):
-        """
-        Retrieve master station 2
-
-        Note this value is 1 indexed, 0 means disabled
-        """
+        """Master station 2 index (1-based; 0 means disabled)."""
         return self._get_option("mas2")
 
     @property
     def master_station_2_time_on_adjustment(self):
-        """
-        Master 1 and 2 on adjusted time (in steps of 5 seconds). Acceptable range is 0 to 600 (note: positive).
-        """
+        """Master 2 on adjustment time (steps of 5 seconds, 0 to 600)."""
         return self._get_option("mton2")
 
     @property
     def master_station_2_time_off_adjustment(self):
-        """
-        Master 1 and 2 off adjusted time (in steps of 5 seconds). Acceptable range is -600 to 0 (note: negative).
-        """
+        """Master 2 off adjustment time (steps of 5 seconds, -600 to 0)."""
         return self._get_option("mtof2")
 
     @property
     def pause_active(self):
-        """Retrieve pause active"""
+        """Whether a pause is currently active."""
         return bool(self._get_variable("pq"))
 
     @property
     def pause_time_remaining(self):
-        """Retrieve remaining pause time, in seconds"""
+        """Remaining pause time in seconds."""
         return self._get_variable("pt")
 
     @property
     def rain_delay_active(self):
-        """Retrieve rain delay active"""
+        """Whether a rain delay is currently active."""
         return bool(self._get_variable("rd"))
 
     @property
     def rain_delay_stop_time(self):
-        """Retrieve rain delay stop time"""
+        """Rain delay stop time as a UTC epoch timestamp."""
         return self._timestamp_to_utc(self._get_variable("rdst"))
 
     @property
     def rain_sensor_active(self):
-        """Retrieve rain sensor active"""
+        """Whether the rain sensor is active, or None if not reported."""
         try:
             return bool(self._get_variable("rs"))
         except KeyError:
@@ -750,7 +901,7 @@ class Controller(object):
 
     @property
     def sensor_1_active(self):
-        """Retrieve sensor 1 active"""
+        """Whether sensor 1 is active, or None if not reported."""
         if self._get_variable("sn1") is not None:
             return bool(self._get_variable("sn1"))
 
@@ -761,7 +912,7 @@ class Controller(object):
 
     @property
     def sensor_1_enabled(self):
-        """Retrieve sensor 1 enabled"""
+        """Whether sensor 1 is enabled, or None if no type is configured."""
         if self.sensor_1_type is None:
             return None
 
@@ -769,7 +920,7 @@ class Controller(object):
 
     @property
     def sensor_1_type(self):
-        """Retrieve sensor 1 type"""
+        """Sensor 1 type integer, or None if not reported."""
         if self._get_option("sn1t") is not None:
             return self._get_option("sn1t")
 
@@ -777,7 +928,7 @@ class Controller(object):
 
     @property
     def sensor_1_type_name(self):
-        """Retrieve sensor 1 type name"""
+        """Sensor 1 type name (e.g. 'rain', 'flow'), or None."""
         if self.sensor_1_type is None:
             return None
 
@@ -785,7 +936,8 @@ class Controller(object):
 
     @property
     def sensor_1_option(self):
-        """Retrieve sensor 1 option"""
+        """Sensor 1 option integer (0 = normally closed, 1 = normally
+        open), or None if not reported."""
         if self._get_option("sn1o") is not None:
             return self._get_option("sn1o")
 
@@ -793,7 +945,8 @@ class Controller(object):
 
     @property
     def sensor_1_option_name(self):
-        """Retrieve sensor 1 option name"""
+        """Sensor 1 option name ('normally_closed' or 'normally_open'),
+        or None."""
         if self.sensor_1_option is None:
             return None
 
@@ -801,25 +954,17 @@ class Controller(object):
 
     @property
     def sensor_1_delayed_on_time(self):
-        """
-        Retrieve sensor 1 delayed on time
-
-        Delayed on time and delayed off time (unit is minutes).
-        """
+        """Sensor 1 delayed on time in minutes."""
         return self._get_option("sn1on")
 
     @property
     def sensor_1_delayed_off_time(self):
-        """
-        Retrieve sensor 1 delayed off time
-
-        Delayed on time and delayed off time (unit is minutes).
-        """
+        """Sensor 1 delayed off time in minutes."""
         return self._get_option("sn1of")
 
     @property
     def sensor_2_active(self):
-        """Retrieve sensor 2 active"""
+        """Whether sensor 2 is active, or None if not reported."""
         if self.sensor_2_type is None:
             return None
 
@@ -827,7 +972,7 @@ class Controller(object):
 
     @property
     def sensor_2_enabled(self):
-        """Retrieve sensor 2 enabled"""
+        """Whether sensor 2 is enabled, or None if no type is configured."""
         if self.sensor_2_type is None:
             return None
 
@@ -835,12 +980,12 @@ class Controller(object):
 
     @property
     def sensor_2_type(self):
-        """Retrieve sensor 2 type"""
+        """Sensor 2 type integer, or None if not reported."""
         return self._get_option("sn2t")
 
     @property
     def sensor_2_type_name(self):
-        """Retrieve sensor 2 type name"""
+        """Sensor 2 type name (e.g. 'rain', 'flow'), or None."""
         if self.sensor_2_type is None:
             return None
 
@@ -848,12 +993,14 @@ class Controller(object):
 
     @property
     def sensor_2_option(self):
-        """Retrieve sensor 2 option"""
+        """Sensor 2 option integer (0 = normally closed, 1 = normally
+        open), or None if not reported."""
         return self._get_option("sn2o")
 
     @property
     def sensor_2_option_name(self):
-        """Retrieve sensor 2 option name"""
+        """Sensor 2 option name ('normally_closed' or 'normally_open'),
+        or None."""
         if self.sensor_2_option is None:
             return None
 
@@ -861,50 +1008,43 @@ class Controller(object):
 
     @property
     def sensor_2_delayed_on_time(self):
-        """
-        Retrieve sensor 2 delayed on time
-
-        Delayed on time and delayed off time (unit is minutes).
-        """
+        """Sensor 2 delayed on time in minutes."""
         return self._get_option("sn2on")
 
     @property
     def sensor_2_delayed_off_time(self):
-        """
-        Retrieve sensor 1 delayed off time
-
-        Delayed on time and delayed off time (unit is minutes).
-        """
+        """Sensor 2 delayed off time in minutes."""
         return self._get_option("sn2of")
 
     @property
     def water_level(self):
-        """Retrieve water level"""
+        """Water level (% Watering), 0-250."""
         return self._get_option("wl")
 
     @property
     def rain_sensor_enabled(self):
-        """Retrieve rain sensor enabled"""
+        """Whether a rain sensor is enabled on either sensor input."""
         return self._sensor_type_enabled(1)
 
     @property
     def flow_sensor_enabled(self):
-        """Retrieve flow sensor enabled"""
+        """Whether a flow sensor is enabled on either sensor input."""
         return self._sensor_type_enabled(2)
 
     @property
     def soil_sensor_enabled(self):
-        """Retrieve soil sensor enabled"""
+        """Whether a soil sensor is enabled on either sensor input."""
         return self._sensor_type_enabled(3)
 
     @property
     def program_switch_sensor_enabled(self):
-        """Retrieve program switch sensor enabled"""
+        """Whether a program switch sensor is enabled on either input."""
         return self._sensor_type_enabled(240)
 
     @property
     def flow_rate(self):
-        """Return flow rate"""
+        """Computed flow rate, or None when no flow sensor is enabled or
+        the reading is unavailable."""
         if not self.flow_sensor_enabled:
             return None
 
@@ -920,32 +1060,33 @@ class Controller(object):
 
     @property
     def flow_count_window(self):
-        """Retrieve flow count window in seconds"""
+        """Flow count window in seconds."""
         return self._get_variable("flwrt")
 
     @property
     def flow_count(self):
-        """Retrieve flow count"""
+        """Flow pulse count within the flow count window."""
         return self._get_variable("flcrt")
 
     @property
     def last_weather_call(self):
-        """Retrieve last weather call"""
+        """Time of the last weather call as a UTC epoch timestamp."""
         return self._timestamp_to_utc(self._get_variable("lwc"))
 
     @property
     def last_successfull_weather_call(self):
-        """Retrieve last successfull weather call"""
+        """Time of the last successful weather call as a UTC epoch
+        timestamp."""
         return self._timestamp_to_utc(self._get_variable("lswc"))
 
     @property
     def last_weather_call_error(self):
-        """Retrieve last weather call error"""
+        """Last weather call error code (0 = success)."""
         return self._get_variable("wterr")
 
     @property
     def last_weather_call_error_name(self):
-        """Retrieve last weather call error name"""
+        """Last weather call error name, or None if unknown/success."""
         if self.last_weather_call_error == -1:
             return WEATHER_ERROR_NOT_RECEIVED
 
@@ -960,35 +1101,27 @@ class Controller(object):
 
     @property
     def sunrise(self):
-        """
-        Retrieve sunrise
-
-        Today’s sunrise time (number of minutes from midnight).
-        """
+        """Today's sunrise time (minutes from midnight)."""
         return self._get_variable("sunrise")
 
     @property
     def sunset(self):
-        """
-        Retrieve sunset
-
-        Today’s sunset time (number of minutes from midnight).
-        """
+        """Today's sunset time (minutes from midnight)."""
         return self._get_variable("sunset")
 
     @property
     def last_reboot_time(self):
-        """Retrieve last device reboot time"""
+        """Last device reboot time as a UTC epoch timestamp."""
         return self._timestamp_to_utc(self._get_variable("lupt"))
 
     @property
     def last_reboot_cause(self):
-        """Retrieve last device reboot cause"""
+        """Last device reboot cause code."""
         return self._get_variable("lrbtc")
 
     @property
     def last_reboot_cause_name(self):
-        """Retrieve last device reboot cause name"""
+        """Last device reboot cause name, or None if unknown."""
         if self.last_reboot_cause == 0:
             return None
 
@@ -1027,22 +1160,22 @@ class Controller(object):
 
     @property
     def mqtt_settings(self):
-        """Retrieve MQTT settings"""
+        """MQTT settings dict, or None if not supported by the firmware."""
         return self._get_variable("mqtt")
 
     @property
     def mqtt_enabled(self):
-        """Return if MQTT is enabled"""
+        """Whether MQTT is enabled, or None if not supported."""
         return (
             bool(self.mqtt_settings["en"]) if self.mqtt_settings is not None else None
         )
 
     @property
     def programs(self):
-        """Return programs"""
+        """Dict of programs keyed by 0-based program index."""
         return self._programs
 
     @property
     def stations(self):
-        """Return stations"""
+        """Dict of stations keyed by 0-based station index."""
         return self._stations

--- a/pyopensprinkler/program.py
+++ b/pyopensprinkler/program.py
@@ -183,33 +183,86 @@ class Program(object):
         return True
 
     async def enable(self):
-        """Enable operation"""
+        """Enable the program.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self.set_enabled(True)
 
     async def disable(self):
-        """Disable operation"""
+        """Disable the program.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self.set_enabled(False)
 
     async def set_enabled(self, value):
+        """Set the program enabled state.
+
+        Args:
+            value: True to enable, False to disable.
+
+        Returns:
+            API result code (1 = success).
+        """
         if value:
             return await self._set_variable("en", 1)
         else:
             return await self._set_variable("en", 0)
 
     async def run(self, uwt=None, qo=None):
-        """Run program"""
+        """Run the program manually.
+
+        Args:
+            uwt: Optional weather adjustment flag (0/1); defaults to the
+                program's ``use_weather_adjustments`` setting.
+            qo: Optional queue option (0 = append to queue, 1 = insert
+                ahead of queue, 2 = replace queue).
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._manual_run(uwt, qo)
 
     async def set_name(self, name):
+        """Set the program name.
+
+        Args:
+            name: New program name.
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[5] = name
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_use_weather_adjustments(self, value):
+        """Set whether the program uses weather (water level) adjustments.
+
+        Args:
+            value: Truthy to enable weather adjustments.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_variable("uwt", int(value))
 
     async def set_odd_even_restriction(self, value):
+        """Set the odd/even day restriction.
+
+        Args:
+            value: 0 = none, 1 = odd days, 2 = even days.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If value is outside 0-2.
+        """
         dlist = self._get_program_data().copy()
         bits = self._get_data_flag_bits()
 
@@ -236,6 +289,24 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_program_schedule_type(self, value):
+        """Set the program schedule type.
+
+        Changing the type resets days0/days1 to defaults since their
+        meaning depends on the schedule type.
+
+        Args:
+            value: 0 = weekly, 1 = single run, 2 = monthly,
+                3 = interval day. Single run and monthly require
+                firmware v2.2.1(1).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If value is single run or monthly
+                and the firmware is older than v2.2.1(1).
+            ValueError: If value is outside 0-3.
+        """
         if value in [
             SCHEDULE_TYPE_SINGLE_RUN_CODE,
             SCHEDULE_TYPE_MONTHLY_CODE,
@@ -275,6 +346,20 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_start_time_type(self, value):
+        """Set the start time type.
+
+        Changing the type resets start1-start3 to defaults since their
+        meaning depends on the start time type.
+
+        Args:
+            value: 0 = repeating, 1 = fixed.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            ValueError: If value is not 0 or 1.
+        """
         dlist = self._get_program_data().copy()
         bits = self._get_data_flag_bits()
 
@@ -297,7 +382,19 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_program_start_time(self, start_index, start_time):
-        """Set program start time with encoded value for start0, 1, 2, or 3"""
+        """Set a program start time.
+
+        Args:
+            start_index: Which start time to set (0-3).
+            start_time: Encoded start time value (minutes from midnight
+                for simple start times).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            IndexError: If start_index is outside 0-3.
+        """
         if not 0 <= start_index <= 3:
             raise IndexError("start_index must be between 0 and 3")
         dlist = self._get_program_data().copy()
@@ -306,14 +403,38 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_program_start_times(self, start_times):
-        """Set program start times with encoded list for start0-start3"""
+        """Set all four program start times at once.
+
+        Args:
+            start_times: List of 4 encoded start time values for
+                start0-start3.
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[3] = start_times
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_program_start_time_offset(self, start_index, start_time_offset):
-        """Set program start time offset in minutes without chaning current offset type"""
+        """Set a program start time offset in minutes.
+
+        Keeps the current offset type; a disabled start time is assumed
+        to become midnight-relative.
+
+        Args:
+            start_index: Which start time to update (0-3).
+            start_time_offset: Offset in minutes (negative for before).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            IndexError: If start_index is outside 0-3.
+            RuntimeError: If start_index > 0 and the start time type is
+                'repeating' (only start0 exists in that mode).
+        """
         if not 0 <= start_index <= 3:
             raise IndexError("start_index must be between 0 and 3")
 
@@ -338,7 +459,24 @@ class Program(object):
     async def set_program_start_time_offset_type(
         self, start_index, start_time_offset_type
     ):
-        """Set program start time offset type ('disabled', 'midnight', 'sunset', or 'sunrise'). Resets minutes to 0."""
+        """Set a program start time offset type.
+
+        Resets the offset minutes to 0.
+
+        Args:
+            start_index: Which start time to update (0-3).
+            start_time_offset_type: One of 'disabled', 'midnight',
+                'sunset', or 'sunrise'.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            IndexError: If start_index is outside 0-3.
+            RuntimeError: If start_index > 0 and the start time type is
+                'repeating' (only start0 exists in that mode).
+            ValueError: If start_time_offset_type is not a valid option.
+        """
         if not 0 <= start_index <= 3:
             raise IndexError("start_index must be between 0 and 3")
 
@@ -361,7 +499,17 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_program_start_repeat_count(self, repeat_count):
-        """Set program start repeat count"""
+        """Set the program start repeat count.
+
+        Args:
+            repeat_count: Number of times to repeat the start.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the start time type is 'fixed'.
+        """
         if self.start_time_type == 1:
             raise RuntimeError(
                 "Cannot update repeat count when start time type is 'fixed'"
@@ -373,7 +521,17 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_program_start_repeat_interval(self, repeat_minutes):
-        """Set program start repeat interval in minutes"""
+        """Set the program start repeat interval.
+
+        Args:
+            repeat_minutes: Interval between repeats in minutes.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the start time type is 'fixed'.
+        """
         if self.start_time_type == 1:
             raise RuntimeError(
                 "Cannot update repeat count when start time type is 'fixed'"
@@ -385,7 +543,18 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_weekday_enabled(self, weekday, enabled):
-        """Set program weekday enabled state (weekday = 'Monday', 'Tuesday', etc.)"""
+        """Set whether the program runs on a given weekday.
+
+        Args:
+            weekday: Weekday name ('Monday', 'Tuesday', etc.).
+            enabled: True to run on that weekday, False to skip it.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the schedule type is not 'weekly'.
+        """
         if self.program_schedule_type != 0:
             raise RuntimeError(
                 "Cannot update Weekly schedule when schedule type is not 'Weekday'"
@@ -397,33 +566,75 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_station_duration(self, station_index, duration):
+        """Set the run duration of one station in the program.
+
+        Args:
+            station_index: 0-based station index.
+            duration: Run duration in seconds (0 to skip the station).
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[4][station_index] = duration
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_station_durations(self, durations):
+        """Set the run durations of all stations in the program.
+
+        Args:
+            durations: List of run durations in seconds, one entry per
+                station (0 to skip a station).
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[4] = durations
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_days0(self, value):
-        """Set days0 (meaning depends on schedule type)"""
+        """Set days0 directly (meaning depends on the schedule type).
+
+        Args:
+            value: Raw days0 value.
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[1] = value
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_days1(self, value):
-        """Set days1 (meaning depends on schedule type)"""
+        """Set days1 directly (meaning depends on the schedule type).
+
+        Args:
+            value: Raw days1 value.
+
+        Returns:
+            API result code (1 = success).
+        """
         dlist = self._get_program_data().copy()
         dlist[2] = value
         params = self._format_program_data(dlist)
         return await self._set_variables(params)
 
     async def set_starting_in_days(self, value):
-        """Set days0 as starting in days in Interval mode)"""
+        """Set 'starting in days' (days0 in Interval-Day mode).
+
+        Args:
+            value: Number of days until the program starts.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the schedule type is not 'Interval-Day'.
+        """
         if self.program_schedule_type != SCHEDULE_TYPE_INTERVAL_DAY_CODE:
             raise RuntimeError(
                 "Cannot update Starting In Days when schedule type is not 'Interval-Day'"
@@ -435,7 +646,17 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_interval_days(self, value):
-        """Set days1 as interval days in Interval mode)"""
+        """Set the interval in days (days1 in Interval-Day mode).
+
+        Args:
+            value: Interval in days (must be >= 1).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the schedule type is not 'Interval-Day'.
+        """
         if self.program_schedule_type != SCHEDULE_TYPE_INTERVAL_DAY_CODE:
             raise RuntimeError(
                 "Cannot update Interval Days when schedule type is not 'Interval-Day'"
@@ -447,7 +668,18 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_monthly_day(self, day_of_month):
-        """Set days0 as monthly day in Monthly mode)"""
+        """Set the day of month to run on (days0 in Monthly mode).
+
+        Args:
+            day_of_month: Day of month, 0-31.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the schedule type is not 'Monthly'.
+            ValueError: If day_of_month is outside 0-31.
+        """
         if self.program_schedule_type != SCHEDULE_TYPE_MONTHLY_CODE:
             raise RuntimeError(
                 "Cannot update Monthly Day when schedule type is not 'Monthly'"
@@ -462,7 +694,19 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_single_run_day(self, days_since_epoch):
-        """Set days0, days1 as single run day in Single-run mode)"""
+        """Set the single run day (days0/days1 in Single-Run mode).
+
+        Args:
+            days_since_epoch: Run day expressed as days since the epoch,
+                0-65535.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            RuntimeError: If the schedule type is not 'Single-run'.
+            ValueError: If days_since_epoch is outside 0-65535.
+        """
         if self.program_schedule_type != SCHEDULE_TYPE_SINGLE_RUN_CODE:
             raise RuntimeError(
                 "Cannot update Single Run Day when schedule type is not 'Single-run'"
@@ -478,7 +722,20 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_date_range_from(self, start_month: int, start_day: int):
-        """Set program date range start date"""
+        """Set the program date range start date.
+
+        Args:
+            start_month: Start month (1-12).
+            start_day: Start day of month (1-31).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is older than
+                v2.2.0(1).
+            ValueError: If the date is invalid.
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
@@ -491,7 +748,20 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_date_range_to(self, end_month: int, end_day: int):
-        """Set program date range end date"""
+        """Set the program date range end date.
+
+        Args:
+            end_month: End month (1-12).
+            end_day: End day of month (1-31).
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is older than
+                v2.2.0(1).
+            ValueError: If the date is invalid.
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
@@ -504,7 +774,19 @@ class Program(object):
         return await self._set_variables(params)
 
     async def set_date_range_flag(self, enabled: bool):
-        """Adjust program date range flag"""
+        """Enable or disable the program date range restriction.
+
+        Args:
+            enabled: 1 to enable, 0 to disable.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is older than
+                v2.2.0(1).
+            ValueError: If enabled is not 0 or 1.
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
@@ -538,6 +820,7 @@ class Program(object):
 
     @property
     def is_running(self):
+        """Whether any station is currently running this program."""
         for _, station in self._controller.stations.items():
             if (
                 station.is_running
@@ -571,6 +854,8 @@ class Program(object):
 
     @property
     def odd_even_restriction_name(self):
+        """Odd/even restriction name ('odd_days' or 'even_days'),
+        or None if unrestricted."""
         value = self.odd_even_restriction
 
         if value == 0 or value == 3:
@@ -599,6 +884,8 @@ class Program(object):
 
     @property
     def program_schedule_type_name(self):
+        """Program schedule type name ('weekday', 'single-run',
+        'monthly', or 'interval_day'), or None."""
         value = self.program_schedule_type
 
         if value == SCHEDULE_TYPE_WEEKLY_CODE:
@@ -617,10 +904,12 @@ class Program(object):
 
     @property
     def start_time_type(self):
+        """Start time type integer (0 = repeating, 1 = fixed)."""
         return self._get_data_flag_bits()[6]
 
     @property
     def start_time_type_name(self):
+        """Start time type name ('repeating' or 'fixed_time'), or None."""
         value = self.start_time_type
 
         if value == 0:
@@ -631,7 +920,10 @@ class Program(object):
 
     @property
     def date_range_enabled(self):
-        """Retrieve Date-range enable flag"""
+        """Whether the date range restriction is enabled.
+
+        Returns 0 on firmware older than v2.2.0(1).
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             return 0
         else:
@@ -639,7 +931,10 @@ class Program(object):
 
     @property
     def date_range_from(self):
-        """Retrieve date range start date"""
+        """Date range start as a (month, day) tuple.
+
+        Returns (1, 1) on firmware older than v2.2.0(1).
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             return 1, 1  # Jan 1 default
         else:
@@ -650,7 +945,10 @@ class Program(object):
 
     @property
     def date_range_to(self):
-        """Retrieve date range end date"""
+        """Date range end as a (month, day) tuple.
+
+        Returns (12, 31) on firmware older than v2.2.0(1).
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             return 12, 31  # Dec 31 default
         else:
@@ -660,7 +958,15 @@ class Program(object):
             return month, day
 
     def get_program_start_time(self, start_index):
-        """Retrieve program start time in encoded value"""
+        """Retrieve a program start time as an encoded value.
+
+        Args:
+            start_index: Which start time to retrieve (0-3).
+
+        Returns:
+            Encoded start time value (minutes from midnight for simple
+            start times).
+        """
         return self._get_variable(3)[start_index]
 
     @property
@@ -669,7 +975,17 @@ class Program(object):
         return self._get_variable(3)
 
     def get_program_start_time_offset(self, start_index):
-        """Retrieve program start time offset in minutes"""
+        """Retrieve a program start time offset in minutes.
+
+        Args:
+            start_index: Which start time to retrieve (0-3).
+
+        Returns:
+            Offset in minutes relative to the offset type.
+
+        Raises:
+            IndexError: If start_index is outside 0-3.
+        """
         if not 0 <= start_index <= 3:
             raise IndexError("start_index must be between 0 and 3")
 
@@ -687,7 +1003,18 @@ class Program(object):
         ]
 
     def get_program_start_time_offset_type(self, start_index):
-        """Retrieve program start time offset type ('midnight', 'sunset', or 'sunrise')"""
+        """Retrieve a program start time offset type.
+
+        Args:
+            start_index: Which start time to retrieve (0-3).
+
+        Returns:
+            One of 'disabled', 'midnight', 'sunset', or 'sunrise'; None
+            for start1-3 when the start time type is 'repeating'.
+
+        Raises:
+            IndexError: If start_index is outside 0-3.
+        """
         if not 0 <= start_index <= 3:
             raise IndexError("start_index must be between 0 and 3")
 
@@ -750,6 +1077,13 @@ class Program(object):
         return self._get_variable(2) + (self._get_variable(1) << 8)
 
     def get_weekday_enabled(self, weekday):
-        """Retrieve program weekday enabled state ('Monday', 'Tuesday', etc.)"""
+        """Retrieve whether the program runs on a given weekday.
+
+        Args:
+            weekday: Weekday name ('Monday', 'Tuesday', etc.).
+
+        Returns:
+            True if the program runs on that weekday.
+        """
         weekday_bits = self._get_variable(1)
         return self._is_set(weekday_bits, WEEKDAYS.index(weekday))

--- a/pyopensprinkler/station.py
+++ b/pyopensprinkler/station.py
@@ -79,7 +79,16 @@ class Station(object):
         return await self._set_attribute(bit_update_name + str(bank), bits)
 
     async def run(self, seconds=None, qo=None):
-        """Run station"""
+        """Run the station manually.
+
+        Args:
+            seconds: Run duration in seconds (default 60).
+            qo: Optional queue option (firmware 2.2.1+); False appends to
+                the queue, True inserts ahead of the queue.
+
+        Returns:
+            API result code (1 = success).
+        """
         if seconds is None:
             seconds = 60
         params = {"en": 1, "t": seconds}
@@ -88,29 +97,68 @@ class Station(object):
         return await self._manual_run(params)
 
     async def stop(self, ssta=None):
-        """Stop station"""
+        """Stop the station.
+
+        Args:
+            ssta: Optional shift flag (firmware 2.2.1+); True shifts the
+                remaining stations in the station's group forward.
+
+        Returns:
+            API result code (1 = success).
+        """
         params = {"en": 0}
         if ssta is not None:
             params["ssta"] = int(ssta)
         return await self._manual_run(params)
 
     async def toggle(self):
-        """Toggle station"""
+        """Toggle the station: stop it if running, otherwise run it for
+        the default duration.
+
+        Returns:
+            API result code (1 = success).
+        """
         if self.is_running:
             return await self.stop()
         else:
             return await self.run()
 
     async def set_name(self, name):
+        """Set the station name.
+
+        Args:
+            name: New station name.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self._set_attribute("s" + str(self.index), name)
 
     async def enable(self):
+        """Enable the station.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self.set_enabled(True)
 
     async def disable(self):
+        """Disable the station.
+
+        Returns:
+            API result code (1 = success).
+        """
         return await self.set_enabled(False)
 
     async def set_enabled(self, value):
+        """Set the station enabled state.
+
+        Args:
+            value: True to enable, False to disable.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "stn_dis"
         bit_update_name = "d"
         if value:
@@ -119,6 +167,14 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, True)
 
     async def set_master_1_operation_enabled(self, value):
+        """Set whether the station activates master 1.
+
+        Args:
+            value: True to engage master 1 when the station runs.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "masop"
         bit_update_name = "m"
         if value:
@@ -127,6 +183,14 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_master_2_operation_enabled(self, value):
+        """Set whether the station activates master 2.
+
+        Args:
+            value: True to engage master 2 when the station runs.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "masop2"
         bit_update_name = "n"
         if value:
@@ -135,6 +199,19 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_group(self, value):
+        """Set the station group.
+
+        Args:
+            value: Group id, 0-255.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is older than
+                v2.2.0(1).
+            ValueError: If value is outside 0-255.
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
 
@@ -143,6 +220,14 @@ class Station(object):
         return await self._set_attribute("g" + str(self.index), value)
 
     async def set_rain_delay_ignored(self, value):
+        """Set whether the station ignores rain delay.
+
+        Args:
+            value: True to run even during a rain delay.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "ignore_rain"
         bit_update_name = "i"
         if value:
@@ -151,6 +236,14 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_sensor_1_ignored(self, value):
+        """Set whether the station ignores sensor 1.
+
+        Args:
+            value: True to run even when sensor 1 is active.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "ignore_sn1"
         bit_update_name = "j"
         if value:
@@ -159,6 +252,14 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_sensor_2_ignored(self, value):
+        """Set whether the station ignores sensor 2.
+
+        Args:
+            value: True to run even when sensor 2 is active.
+
+        Returns:
+            API result code (1 = success).
+        """
         bit_property = "ignore_sn2"
         bit_update_name = "k"
         if value:
@@ -167,6 +268,18 @@ class Station(object):
             return await self._bit_set(bit_property, bit_update_name, False)
 
     async def set_sequential_operation(self, value):
+        """Set whether the station runs sequentially (vs. in parallel).
+
+        Args:
+            value: True for sequential operation.
+
+        Returns:
+            API result code (1 = success).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is v2.2.1(0) or
+                newer (feature removed).
+        """
         if not _is_removed_feature_supported(self._controller, 221, 0):
             raise FirmwareNotSupportedError("Feature removed in v2.2.1(0)")
 
@@ -189,11 +302,12 @@ class Station(object):
 
     @property
     def is_running(self):
-        """Retrieve is running flag"""
+        """Whether the station is currently running."""
         return bool(self._controller._state["status"]["sn"][self._index])
 
     @property
     def is_master(self):
+        """Whether the station is configured as master 1 or master 2."""
         # stored in controller 1 indexed vs 0 indexed
         station_id = self.index + 1
         return (
@@ -203,26 +317,23 @@ class Station(object):
 
     @property
     def running_program_id(self):
-        """
-        Retrieve seconds remaining
-
-        Note this value is 1 indexed
-        """
+        """ID of the program running this station (1-based; 0 means
+        none)."""
         return self._get_status_variable(0)
 
     @property
     def seconds_remaining(self):
-        """Retrieve seconds remaining"""
+        """Remaining run time in seconds."""
         return self._get_status_variable(1)
 
     @property
     def start_time(self):
-        """Retrieve start time"""
+        """Start time as a UTC epoch timestamp."""
         return self._controller._timestamp_to_utc(self._get_status_variable(2))
 
     @property
     def end_time(self):
-        """Retrieve end time"""
+        """End time as a UTC epoch timestamp (0 if not started)."""
         if self.start_time == 0:
             return 0
         return (
@@ -231,41 +342,59 @@ class Station(object):
 
     @property
     def max_name_length(self):
+        """Maximum supported station name length."""
         return self._controller._state["stations"]["maxlen"]
 
     @property
     def master_1_operation_enabled(self):
+        """Whether the station activates master 1."""
         return self._bit_check("masop")
 
     @property
     def master_2_operation_enabled(self):
+        """Whether the station activates master 2."""
         return self._bit_check("masop2")
 
     @property
     def group(self):
-        """Station group"""
+        """Station group id.
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is older than
+                v2.2.0(1).
+        """
         if not _is_new_feature_supported(self._controller, 220, 1):
             raise FirmwareNotSupportedError("Feature requires firmware v2.2.0(1)")
         return self._controller._state["stations"]["stn_grp"][self._index]
 
     @property
     def rain_delay_ignored(self):
+        """Whether the station ignores rain delay."""
         return self._bit_check("ignore_rain")
 
     @property
     def sensor_1_ignored(self):
+        """Whether the station ignores sensor 1."""
         return self._bit_check("ignore_sn1")
 
     @property
     def sensor_2_ignored(self):
+        """Whether the station ignores sensor 2."""
         return self._bit_check("ignore_sn2")
 
     @property
     def enabled(self):
+        """Whether the station is enabled."""
         return not self._bit_check("stn_dis")
 
     @property
     def sequential_operation(self):
+        """Whether the station runs sequentially (vs. in parallel).
+
+        Raises:
+            FirmwareNotSupportedError: If the firmware is v2.2.1(0) or
+                newer (feature removed).
+        """
         if not _is_removed_feature_supported(self._controller, 221, 0):
             raise FirmwareNotSupportedError("Feature removed in v2.2.1(0)")
 
@@ -273,10 +402,12 @@ class Station(object):
 
     @property
     def special(self):
+        """Whether the station is a special station (e.g. RF, remote)."""
         return self._bit_check("stn_spe")
 
     @property
     def station_type(self):
+        """Station type ('standard'), or None for special stations."""
         if not self.special:
             return STATION_TYPE_STANDARD
 
@@ -286,7 +417,8 @@ class Station(object):
 
     @property
     def status(self):
-        """Retrieve status"""
+        """Station status name: 'idle', 'manual', 'master_engaged',
+        'once_program', 'program', or 'waiting'."""
         is_running = self.is_running
         pid = self.running_program_id
 


### PR DESCRIPTION
- Add Google-style docstrings (Args/Returns/Raises) to all public Controller, Program, and Station methods
- Document every property with return types, units, ranges, and None/fallback cases
- Fix request() docstring placement so it is a real docstring
- Fix incorrect docstrings on sensor_2_delayed_off_time and running_program_id
- No code changes; docstrings only

Fixes #3